### PR TITLE
Angular heavy 2 minor fixes

### DIFF
--- a/src/main/webapp/partial/queue-list.html
+++ b/src/main/webapp/partial/queue-list.html
@@ -23,7 +23,7 @@
       </form>
     </div>
     <div class="medium-4 columns pull-right">
-      <input ng-model="search.name" type="text" placeholder="Filter queues"/>
+      <input ng-model="search.title" type="text" placeholder="Filter queues"/>
     </div>
   </div>
   <div class="radius queue-row"


### PR DESCRIPTION
Just two very minor changes. Changed so that the queue filter only filters queue names. As it was earlier, it filtered on almost anything that had to do with the queue (comments of people in the queue, locations etc.).
