### PR TITLE
Fix top bar overflow

### DIFF
--- a/src/main/scss/style.scss
+++ b/src/main/scss/style.scss
@@ -65,3 +65,7 @@
   from { opacity:1; }
   to { opacity:0; }
 }
+
+.top-bar {
+  overflow: hidden;
+}


### PR DESCRIPTION
The right side of the top bar may overflow with 1 px if the `strong` kth-id has 'low' letters such as 'p'.
This can be circumvented with this css, though there might be an integrated fix in Foundation (which I don't know about).
