### PR TITLE
Change from admin to owner/moderator for removing queue position

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>se.kth.csc</groupId>
     <artifactId>qwait</artifactId>
     <packaging>war</packaging>
-    <version>1.0.10</version>
+    <version>1.0.11</version>
     <name>QWait</name>
     <description>A queuing system for assistance management</description>
     <properties>

--- a/src/main/webapp/partial/queue.html
+++ b/src/main/webapp/partial/queue.html
@@ -244,7 +244,7 @@
               <td width="1" class="show-for-medium-up">{{$index + 1}}</td>
               <td>
                 {{getUser(position.userName).readableName}}
-                <span ng-show="users.current.admin" ng-controller="RemoveUserModalCtrl">
+                <span ng-show="canModerateQueue(users.current, queue)" ng-controller="RemoveUserModalCtrl">
                   <script type="text/ng-template" id="remove-user-modal-content.html">
                     <h3>Remove {{getUser(position.userName).readableName}} from {{queue.title}}</h3>
                     <p>This will remove the user from the queue.</p>


### PR DESCRIPTION
In the previous version only an admin could remove a user in a queue. This changes it to enable queue owners and moderators to remove queue positions. 
