### PR TITLE
Fix bug on remove admin where queue owners can see the button

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>se.kth.csc</groupId>
     <artifactId>qwait</artifactId>
     <packaging>war</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <name>QWait</name>
     <description>A queuing system for assistance management</description>
     <properties>

--- a/src/main/webapp/partial/admin.html
+++ b/src/main/webapp/partial/admin.html
@@ -45,14 +45,14 @@
               <tr>
                 <th>Name</th>
                 <th>KTH-id</th>
-                <th ng-if="users.admins.length">&nbsp;</th>
+                <th ng-if="users.admins.length && users.current.admin">&nbsp;</th>
               </tr>
               </thead>
               <tbody>
               <tr ng-repeat="admin in users.admins">
                 <td>{{admin.readableName}}</td>
                 <td>{{admin.name}}</td>
-                <td ng-if="users.admins.length" ng-controller="RemoveAdminModalCtrl">
+                <td ng-if="users.admins.length && users.current.admin" ng-controller="RemoveAdminModalCtrl">
                   <script type="text/ng-template" id="remove-admin-modal-content.html">
                     <h3>Remove admin {{position.readableName}}</h3>
                     <p>This will remove the user as an admin for QWait.</p>


### PR DESCRIPTION
In old version queue owners could click the red cross button (but nothing happened).
